### PR TITLE
You don't actually need to be root to use this

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,6 @@
 ```sh
 usermod -G auth <yourdaemonuser>
 ```
-
-For some login styles, you may also need to be in additional groups:
-
-```sh
-usermod -G _token <yourdaemonuser>  # for style in ['activ', 'crypto', 'snk', 'token']
-usermod -G _radius <yourdaemonuser>  # for style == 'radius'
-```
  
 Usage:
 ```sh

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 - Currently only implements auth_userokay(3) since this is most suitable for authenticating to OpenBSD from python
 
 ### Note
-- Your application must have root privileges in order to use this module.
-
+- Your application must privileges to use the particular login style. This means it must either be running as root, be running a privileged helped as root, or be in the 'auth' group.
+ 
 Usage:
 ```sh
 >>> from bsdauth.bsdauth import UserOkay

--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@
 - Currently only implements auth_userokay(3) since this is most suitable for authenticating to OpenBSD from python
 
 ### Note
-- Your application must privileges to use the particular login style. This means it must either be running as root, be running a privileged helped as root, or be in the 'auth' group.
+- Your application must be in the 'auth' group to call auth_userokay(3):
+
+```sh
+usermod -G auth <yourdaemonuser>
+```
+
+For some login styles, you may also need to be in additional groups:
+
+```sh
+usermod -G _token <yourdaemonuser>  # for style in ['activ', 'crypto', 'snk', 'token']
+usermod -G _radius <yourdaemonuser>  # for style == 'radius'
+```
  
 Usage:
 ```sh

--- a/bsdauth/bsdauth.py
+++ b/bsdauth/bsdauth.py
@@ -16,9 +16,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 from ctypes import CDLL, c_char_p
 import os, pwd, re
 
-def _get_username():
-    return pwd.getpwuid( os.getuid() )[ 0 ]
-
 
 class Validator(object):
     def is_username_valid(self, username):
@@ -70,9 +67,6 @@ class UserOkay(object):
             again. If calling process is not owned by root return None. root privilege 
             is required by BSD Auth.
         """
-        if _get_username() != 'root':
-            return None
-
         sofile = '/usr/lib/libc.so*'
         authstyle = c_char_p()
         authstyle.value = str.encode('passwd')


### PR DESCRIPTION
You can also be in the `auth` group. The `auth_userokay` manpage doesn't explain this very well, unfortunately.

The way it actually works is: `auth_userokay` (and friends) defer to programs in /usr/libexec/auth/:

```
comms3$ ls -ld /usr/libexec/auth/          
drwxr-x---  2 root  auth  512 Apr 19 18:16 /usr/libexec/auth/
comms3$ doas ls -l /usr/libexec/auth/  
total 428
-r-xr-sr-x  4 root  _token   19584 Apr 19 18:16 login_activ
-r-sr-xr-x  1 root  auth      6520 Apr 19 18:16 login_chpass
-r-xr-sr-x  4 root  _token   19584 Apr 19 18:16 login_crypto
-r-sr-xr-x  1 root  auth     17224 Apr 19 18:16 login_lchpass
-r-xr-xr-x  1 root  bin      37448 Apr 19 18:16 login_ldap
-r-sr-xr-x  1 root  auth      8512 Apr 19 18:16 login_passwd
-r-xr-sr-x  1 root  _radius  17632 Apr 19 18:16 login_radius
-r-xr-xr-x  1 root  auth      7128 Apr 19 18:16 login_reject
-r-xr-sr-x  1 root  auth     11280 Apr 19 18:16 login_skey
-r-xr-sr-x  4 root  _token   19584 Apr 19 18:16 login_snk
-r-xr-sr-x  4 root  _token   19584 Apr 19 18:16 login_token
-r-xr-sr-x  1 root  auth     21536 Apr 19 18:16 login_yubikey
comms3$ doas ls -l /usr/libexec/auth/login_ldap
-r-xr-xr-x  1 root  bin  37448 Apr 19 18:16 /usr/libexec/auth/login_ldap
```

If you're not in 'auth' you can't use any of them because you can't see any of them:

```
comms3$ ls -l /usr/libexec/auth/
total 0
ls: /usr/libexec/auth/: Permission denied
comms3$ /usr/libexec/auth/login_ldap
ksh: /usr/libexec/auth/login_ldap: not found
```

So rather than forcing root on people, the default instructions should be something like `usermod -G auth <yourdaemonuser>`.